### PR TITLE
CSS-IN-JS POC

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@
     "no-underscore-dangle": 0,
     "no-unused-vars": 0,
     "react/jsx-filename-extension": 0,
+    "react/forbid-prop-types": ["any", "array"],
     "require-jsdoc": 0,
     "valid-jsdoc": 0,
     "jest/consistent-test-it": "error",

--- a/components.json
+++ b/components.json
@@ -43,6 +43,7 @@
   {
     "name": "Design System Icons",
     "components": [
+      "WDSIcon",
       "VideoPlayIcon"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lodash.uniqueid": "^4.0.1",
     "prop-types": "^15.6.1",
     "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react-dom": "^16.2.0",
+    "react-jss": "^8.6.1"
   },
   "scripts": {
     "build:watch": "styleguidist server",

--- a/src/components/BannerNotification/index.js
+++ b/src/components/BannerNotification/index.js
@@ -1,48 +1,82 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import './styles.scss';
+import injectStyles from 'react-jss';
+
+import WDSIcon from '../WDSIcon';
 
 function getIcon(type) {
   switch (type) {
     case ('alert'):
-      return '#wds-icons-error-small';
+      return 'error-small';
     case ('warning'):
-      return '#wds-icons-alert-small';
+      return 'alert-small';
     case ('success'):
-      return '#wds-icons-checkmark-circle-small';
+      return 'circle-small';
     default:
-      return '#wds-icons-flag-small';
+      return 'flag-small';
   }
 }
 
-function getClassName(type) {
+function getBackgroundColor({colors}, type) {
   switch (type) {
     case ('alert'):
-      return 'wds-alert';
+      return colors.alert;
     case ('warning'):
-      return 'wds-warning';
+      return colors.warning;
     case ('success'):
-      return 'wds-success';
+      return colors.success;
     default:
-      return 'wds-message';
+      return colors.message;
   }
 }
+
+const styles = theme => ({
+  root: {
+    backgroundColor: theme.colors.background,
+    color: theme.colors.bodyText,
+    display: 'flex',
+    transition: 'opacity 0.4s',
+  },
+  icon: {
+    alignItems: 'center',
+    color: theme.colors.background,
+    display: 'flex',
+    justifyContent: 'center',
+    width: '48px',
+    backgroundColor: props => getBackgroundColor(theme, props.type),
+  },
+  text: {
+    color: theme.colors.bodyText,
+    flex: 1,
+    fontSize: theme.typography.minus2,
+    lineHeight: theme.typography.lineHeight.minus2,
+    padding: {
+      top: 13,
+      bottom: 13,
+      left: 12,
+      right: 12,
+    },
+  },
+  close: {
+    cursor: 'pointer',
+    padding: 18,
+    fill: theme.colors.alert,
+  },
+});
+
+// create icon component
 
 /**
  * This is a single component used in `BannerNotifications` component.
  */
-const BannerNotification = ({className, type, text, onClose}) => (
-  <div className={`wds-banner-notification ${getClassName(type)} ${className}`}>
-    <div className="wds-banner-notification__icon">
-      <svg className="wds-icon wds-icon-small">
-        <use xmlnsXlink="http://www.w3.org/1999/xlink" xlinkHref={getIcon(type)} />
-      </svg>
+const BannerNotification = ({className, type, text, onClose, classes}) => (
+  <div className={classes.root}>
+    <div className={classes.icon}>
+      <WDSIcon icon={getIcon(type)} fill="white"/>
     </div>
-    <span className="wds-banner-notification__text">{text}</span>
+    <span className={classes.text}>{text}</span>
     {onClose && (
-      <svg className="wds-icon wds-icon-tiny wds-banner-notification__close" onClick={onClose}>
-        <use xmlnsXlink="http://www.w3.org/1999/xlink" xlinkHref="#wds-icons-cross-tiny" />
-      </svg>
+      <WDSIcon className={classes.close} size={2} icon="cross-tiny" fill="red" onClick={onClose} />
     )}
   </div>
 );
@@ -52,6 +86,7 @@ BannerNotification.propTypes = {
   type: PropTypes.oneOf(['alert', 'warning', 'success', 'message']).isRequired,
   text: PropTypes.string.isRequired,
   onClose: PropTypes.func,
+  classes: PropTypes.object.isRequired,
 };
 
 BannerNotification.defaultProps = {
@@ -59,4 +94,4 @@ BannerNotification.defaultProps = {
   onClose: null,
 };
 
-export default BannerNotification;
+export default injectStyles(styles)(BannerNotification);

--- a/src/components/BannerNotification/styles.scss
+++ b/src/components/BannerNotification/styles.scss
@@ -1,7 +1,0 @@
-// import variables
-@import "~design-system/dist/scss/wds-functions/index.scss";
-@import "~design-system/dist/scss/wds-mixins/index.scss";
-@import "~design-system/dist/scss/wds-variables/index.scss";
-
-// import wds-button
-@import "~design-system/dist/scss/wds-components/_banner-notification.scss";

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -1,6 +1,33 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import injectSheet from 'react-jss';
 import './styles.scss';
+
+const styles = theme => ({
+  root: {
+    alignItems: 'center',
+    borderStyle: 'solid',
+    backgroundColor: theme.colors.primary,
+    borderColor: theme.colors.primary,
+    color: theme.colors.primaryText,
+    borderWidth: 1,
+    borderRadius: theme.shape.borderRadius,
+    boxSizing: 'content-box',
+    fontSize: theme.typography.minus2,
+    fontWeight: theme.typography.weight.strong,
+    margin: 0,
+    padding: {
+      top: theme.spacing.unit,
+      bottom: theme.spacing.unit,
+      left: theme.spacing.unit * 2,
+      right: theme.spacing.unit * 2,
+    },
+    transitionDuration: theme.transition.duration,
+    transitionProperty: 'background-color, border-color, color',
+    textTransform: 'uppercase',
+    '-webkit-appearance': 'none',
+  },
+});
 
 /**
  * Basic button component
@@ -13,22 +40,23 @@ const Button = ({
   square,
   fullwidth,
   children,
+  classes,
   ...rest
 }) => {
-  const classes = [
-    'wds-button',
-    className,
-    secondary ? 'wds-is-secondary' : '',
-    square ? 'wds-is-square' : '',
-    text ? 'wds-is-text' : '',
-    fullwidth ? 'wds-is-fullwidth' : '',
-  ].filter(c => c).join(' ');
+  // const classes = [
+  //   'wds-button',
+  //   className,
+  //   secondary ? 'wds-is-secondary' : '',
+  //   square ? 'wds-is-square' : '',
+  //   text ? 'wds-is-text' : '',
+  //   fullwidth ? 'wds-is-fullwidth' : '',
+  // ].filter(c => c).join(' ');
 
   if (href) {
-    return <a href={href} className={classes} {...rest}>{children}</a>;
+    return <a href={href} className={classes.root} {...rest}>{children}</a>;
   }
 
-  return <button className={classes} {...rest}>{children}</button>;
+  return <button className={classes.root} {...rest}>{children}</button>;
 };
 
 Button.propTypes = {
@@ -83,4 +111,4 @@ Button.defaultProps = {
   onClick: () => {},
 };
 
-export default Button;
+export default injectSheet(styles)(Button);

--- a/src/components/Spinner/index.js
+++ b/src/components/Spinner/index.js
@@ -1,7 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import injectSheet from 'react-jss';
 
-import './styles.scss';
+const styles = theme => ({
+  root: {
+    display: 'inline-flex',
+    width: props => props.size,
+    height: props => props.size,
+  },
+  svg: {
+    animation: 'fandom-spinner-rotator .5s linear infinite',
+    transform: 'translateZ(0)',
+  },
+  circle: {
+    '-webkit-backface-visibility': 'hidden',
+    'backface-visbility': 'hidden',
+    animation: 'fandom-spinner-dash 1.25s linear infinite alternate-reverse',
+    stroke: theme.colors.link,
+  },
+  '@keyframes fandom-spinner-rotator': {
+    from: `transform: rotate(0)`,
+    to: 'transform: rotate(360deg)',
+  },
+  '@keyframes fandom-spinner-dash': {
+    to: `stroke-dashoffset: 0`,
+  },
+});
 
 /**
  * Loader block component used to indicate loading state.
@@ -12,6 +36,7 @@ const Spinner = ({
   className,
   size,
   stroke,
+  classes,
 }) => {
   const style = {
     width: size,
@@ -23,15 +48,17 @@ const Spinner = ({
   const dash = 2 * Math.PI * r;
 
   return (
-    <div className={`fandom-spinner ${className}`} style={style}>
+    <div className={classes.root}>
       <svg
         width={size}
         height={size}
         viewBox={`0 0 ${size} ${size}`}
         xmlns="http://www.w3.org/2000/svg"
+        className={classes.svg}
       >
         <g transform={`translate(${translate}, ${translate})`}>
           <circle
+            className={classes.circle}
             fill="none"
             strokeWidth={stroke}
             strokeDasharray={dash}
@@ -46,6 +73,10 @@ const Spinner = ({
 };
 
 Spinner.propTypes = {
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes: PropTypes.object.isRequired,
   /**
    * Additional class name
    */
@@ -66,4 +97,4 @@ Spinner.defaultProps = {
   stroke: 2,
 };
 
-export default Spinner;
+export default injectSheet(styles)(Spinner);

--- a/src/components/WDSIcon/README.md
+++ b/src/components/WDSIcon/README.md
@@ -1,0 +1,24 @@
+Defaults:
+```js
+  <WDSIcon icon="cross-tiny" fill="rgba(1,1,1,0.5)"/>
+```
+
+Icon Selection:
+```js
+  <>
+  	<WDSIcon icon="camera" fill="rebeccapurple"/>
+  	<WDSIcon icon="bold" fill="rgb(1,1,1)"/>
+  	<WDSIcon icon="arrow" fill="green"/>
+  	<WDSIcon icon="bell" fill="#1a1a1a"/>
+  </>
+```
+
+Sizing (multiples of `theme.spacing.unit`):
+```js
+  <>
+    <WDSIcon icon="bell" size={4} />
+    <WDSIcon icon="camera" size={8} />
+  </>
+```
+
+See [fandomdesignsystem](https://fandomdesignsystem.com/#/components/assets) for complete list

--- a/src/components/WDSIcon/__snapshots__/index.spec.js.snap
+++ b/src/components/WDSIcon/__snapshots__/index.spec.js.snap
@@ -1,0 +1,103 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Button renders correctly as link 1`] = `
+<a
+  className="wds-button"
+  disabled={false}
+  href="some link"
+  onClick={[Function]}
+>
+  a link
+</a>
+`;
+
+exports[`Button renders correctly fullwidth button 1`] = `
+<button
+  className="wds-button wds-is-fullwidth"
+  disabled={false}
+  onClick={[Function]}
+>
+  a WIDE button
+</button>
+`;
+
+exports[`Button renders correctly with a children 1`] = `
+<button
+  className="wds-button"
+  disabled={false}
+  onClick={[Function]}
+>
+  <strong>
+    bold
+  </strong>
+   text
+</button>
+`;
+
+exports[`Button renders correctly with a label 1`] = `
+<button
+  className="wds-button"
+  disabled={false}
+  onClick={[Function]}
+>
+  a button
+</button>
+`;
+
+exports[`Button renders correctly with custom types values 1`] = `
+<button
+  className="wds-button"
+  disabled={true}
+  onClick={[Function]}
+>
+  disabled
+</button>
+`;
+
+exports[`Button renders correctly with custom types values 2`] = `
+<button
+  className="wds-button wds-is-secondary"
+  disabled={false}
+  onClick={[Function]}
+>
+  secondary
+</button>
+`;
+
+exports[`Button renders correctly with custom types values 3`] = `
+<button
+  className="wds-button wds-is-text"
+  disabled={false}
+  onClick={[Function]}
+>
+  text
+</button>
+`;
+
+exports[`Button renders correctly with custom types values 4`] = `
+<button
+  className="wds-button wds-is-square"
+  disabled={false}
+  onClick={[Function]}
+>
+  …
+</button>
+`;
+
+exports[`Button renders correctly with custom types values 5`] = `
+<button
+  className="wds-button custom-class"
+  disabled={false}
+  onClick={[Function]}
+>
+  with custom class name
+</button>
+`;
+
+exports[`Button renders correctly with default values 1`] = `
+<button
+  className="wds-button"
+  disabled={false}
+  onClick={[Function]}
+/>
+`;

--- a/src/components/WDSIcon/index.js
+++ b/src/components/WDSIcon/index.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import injectStyles from 'react-jss';
+
+const styles = theme => ({
+  root: {
+    fill: ({fill}) => fill,
+    height: ({size}) => size * theme.spacing.unit,
+    minWidth: ({size}) => size * theme.spacing.unit,
+    width: ({size}) => size * theme.spacing.unit,
+  },
+});
+
+const WDSIcon = ({classes, icon, className}) => (
+  <svg className={`${classes.root} ${className}`}>
+    <use xmlnsXlink="http://www.w3.org/1999/xlink" xlinkHref={`#wds-icons-${icon}`} />
+  </svg>
+);
+
+WDSIcon.propTypes = {
+  /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * @ignore
+   */
+  classes: PropTypes.object.isRequired,
+  /**
+   * Multiple of `theme.spacing.unit`
+   */
+  size: PropTypes.number,
+  /**
+   * String name of wds icon.
+   * @see See [fandomdesignsystem](https://fandomdesignsystem.com/#/components/assets) for complete list
+   */
+  icon: PropTypes.string.isRequired,
+  /**
+   * Color to fill svg in
+   *
+   */
+  fill: PropTypes.string,
+};
+
+WDSIcon.defaultProps = {
+  children: null,
+  className: '',
+  size: 2,
+  fill: 'purple',
+};
+
+export default injectStyles(styles)(WDSIcon);

--- a/src/components/WDSIcon/index.spec.js
+++ b/src/components/WDSIcon/index.spec.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import {shallow} from 'enzyme';
+import sinon from 'sinon';
+
+import WDSIcon from './index';
+
+/* eslint-disable no-alert */
+
+test('Icon with default values', () => {
+  const component = renderer.create(
+    <WDSIcon icon="cross-tiny" />,
+  );
+  expect(component.toJSON()).toMatchSnapshot();
+});
+
+test('Icon with color prop', () => {
+  const component = renderer.create(
+    <WDSIcon icon="cross-tiny" fill="rgba(1,1,1,0.5)"/>,
+  );
+  expect(component.toJSON()).toMatchSnapshot();
+});
+
+test('Icon with color prop and size', () => {
+  const component = renderer.create(
+    <WDSIcon icon="cross-tiny" fill="rgba(1,1,1,0.5)" size={10} />,
+  );
+  expect(component.toJSON()).toMatchSnapshot();
+});

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,8 @@ export {default as BannerNotifications} from './components/BannerNotifications';
 
 // Icons
 export {default as VideoPlayIcon} from './components/VideoPlayIcon';
+export {default as WDSIcon} from './components/WDSIcon';
+
 // Usefull flow components
 export {default as ContentWell} from './components/ContentWell';
 export {default as FandomContentWell} from './components/FandomContentWell';
@@ -22,3 +24,6 @@ export {default as Vignette} from './components/Vignette';
 // custom types
 export {default as bannerNotificationsMessageType}
   from './components/BannerNotifications/bannerNotificationsMessageType';
+
+export {default as ReactDesignSystemThemeProvider} from './styles/ReactDesignSystemThemeProvider';
+

--- a/src/styles/ReactDesignSystemThemeProvider.js
+++ b/src/styles/ReactDesignSystemThemeProvider.js
@@ -1,0 +1,19 @@
+import React, {Component} from 'react';
+import {ThemeProvider} from 'react-jss';
+import theme from './theme';
+
+// TODO: Add ability to namespace the theme that is created
+// export const ThemeWrapper = ({children}) => <ThemeProvider theme={theme}> {children} </ThemeProvider>;
+
+
+export default class ThemeWrapper extends Component {
+  render() {
+    const mergedTheme = {...theme, ...this.props.theme};
+
+    return (
+      <ThemeProvider theme={mergedTheme}>
+        {this.props.children}
+      </ThemeProvider>
+    )
+  }
+}

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,0 +1,70 @@
+const palette = {
+  aqua: '#00d6d6',
+  black: '#1a1a1a',
+  coral: '#ff6a64',
+  darkGray: '#5f7a7b',
+  lightGray: '#f2f5f5',
+  link: '#00acac',
+  linkHover: '#008989',
+  midLightGray: '#dee7e5',
+  middleGray: '#bed1cf',
+  mint: '#5df2ae',
+  navy: '#002a32',
+  pine: '#006661',
+  plum: '#833c58',
+  purple: '#460084',
+  red: '#ee1a41',
+  warmGray: '#eeecdc',
+  yellow: '#dfec24',
+  white: '#fff',
+  alert: '#d71035',
+  warning: '#dfec24',
+  success: '#4cda9a',
+  message: '#460084',
+};
+
+const spacing = {
+  unit: 8,
+};
+
+const shape = {
+  borderRadius: 4,
+};
+
+export default {
+  colors: {
+    primary: palette.aqua,
+    primaryText: '#fff',
+    secondary: palette.yellow,
+    background: '#fff',
+    link: palette.link,
+    bodyText: palette.darkGray,
+    alert: palette.alert,
+    warning: palette.warning,
+    success: palette.success,
+    message: palette.message,
+    palette,
+  },
+  typography: {
+    base: 16,
+    minus3: 10,
+    minus2: 12,
+    minus1: 14,
+    plus1: 18,
+    plus2: 24,
+    plus3: 28,
+    lineHeight: {
+      minus2: 1.29,
+    },
+    weight: {
+      bold: 400,
+      strong: 600,
+    },
+  },
+  shape,
+  spacing,
+  transition: {
+    duration: 100,
+  },
+};
+

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -49,4 +49,7 @@ module.exports = {
   require: [
     path.join(__dirname, 'node_modules/design-system/dist/css/styles.css'),
   ],
+  styleguideComponents: {
+    Wrapper: path.join(__dirname, 'src/styles/ReactDesignSystemThemeProvider'),
+  },
 };

--- a/styleguide/CONTRIBUTION.md
+++ b/styleguide/CONTRIBUTION.md
@@ -3,9 +3,10 @@
 - general [Fandom's JavaScript](https://github.com/Wikia/eslint-config-fandom) rules apply (with the exception of whitespaces, check [`.editorconfig`](https://github.com/Wikia/react-design-system/blob/master/.editorconfig) file)
 - Use function syntax if possible, use nesting and flat files.
 - 100% coverage and no regressions
-- use [Jest](https://facebook.github.io/jest/) as a general testing framework and for testing component's rendering
-- use [Enzyme](https://github.com/airbnb/enzyme) for testing interactions
-- use [Sinon](http://sinonjs.org/) for testing callbacks
+  - use [Jest](https://facebook.github.io/jest/) as a general testing framework and for testing component's rendering
+  - use [Enzyme](https://github.com/airbnb/enzyme) for testing interactions
+  - use [Sinon](http://sinonjs.org/) for testing callbacks3
+- **Components spacing (especially vertical) should never be hard coded rather a multiple of `theme.spacing.unit`**
 
 ## Step-by-step guide
 0. Assuming the new component's name is `ComponentA` all it's files will be in `/src/components/ComponentA/` directory.
@@ -56,3 +57,7 @@ The script will automatically pull newest `master` branch, build the documentati
 ```js static
 > yarn release:major
 ```
+
+### TODO: 
+* Add type for theme variables
+* Create Icon Component: https://material-ui.com/style/icons/

--- a/styleguide/INSTALLATION.md
+++ b/styleguide/INSTALLATION.md
@@ -46,3 +46,21 @@ resolve: {
     ]
 },
 ```
+
+#### CSS-IN-JS
+
+
+##### Theming
+note: the theming by default will __not__ be namespaced as the theme is meant to be standardized across FANDOM apps.
+
+```js static
+import {ReactDesignSystemThemeProvider} from '@wikia/react-design-system';
+const theme = {}; // your theme overrides
+
+<ReactDesignSystemThemeProvider theme={theme}>
+    <App />
+</ReactDesignSystemThemeProvider>
+```
+
+#### SSR Setup
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,6 +1228,10 @@ braces@^2.3.0, braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
+brcast@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/brcast/-/brcast-3.0.1.tgz#6256a8349b20de9eed44257a9b24d71493cd48dd"
+
 brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
@@ -2066,6 +2070,12 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
+
+css-vendor@^0.3.8:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-0.3.8.tgz#6421cfd3034ce664fe7673972fd0119fc28941fa"
+  dependencies:
+    is-in-browser "^1.0.2"
 
 css-what@2.1:
   version "2.1.0"
@@ -3713,6 +3723,10 @@ hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
+hoist-non-react-statics@^2.5.0:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -4138,6 +4152,10 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
 
+is-function@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
+
 is-generator-fn@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-1.0.0.tgz#969d49e1bb3329f6bb7f09089be26578b2ddd46a"
@@ -4164,7 +4182,7 @@ is-hexadecimal@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.1.tgz#6e084bbc92061fbb0971ec58b6ce6d404e24da69"
 
-is-in-browser@^1.1.3:
+is-in-browser@^1.0.2, is-in-browser@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
 
@@ -4839,6 +4857,16 @@ jss-default-unit@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/jss-default-unit/-/jss-default-unit-8.0.2.tgz#cc1e889bae4c0b9419327b314ab1c8e2826890e6"
 
+jss-expand@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/jss-expand/-/jss-expand-5.3.0.tgz#02be076efe650125c842f5bb6fb68786fe441ed6"
+
+jss-extend@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/jss-extend/-/jss-extend-6.2.0.tgz#4af09d0b72fb98ee229970f8ca852fec1ca2a8dc"
+  dependencies:
+    warning "^3.0.0"
+
 jss-global@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/jss-global/-/jss-global-3.0.0.tgz#e19e5c91ab2b96353c227e30aa2cbd938cdaafa2"
@@ -4853,6 +4881,45 @@ jss-nested@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/jss-nested/-/jss-nested-6.0.1.tgz#ef992b79d6e8f63d939c4397b9d99b5cbbe824ca"
   dependencies:
+    warning "^3.0.0"
+
+jss-preset-default@^4.3.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/jss-preset-default/-/jss-preset-default-4.5.0.tgz#d3a457012ccd7a551312014e394c23c4b301cadd"
+  dependencies:
+    jss-camel-case "^6.1.0"
+    jss-compose "^5.0.0"
+    jss-default-unit "^8.0.2"
+    jss-expand "^5.3.0"
+    jss-extend "^6.2.0"
+    jss-global "^3.0.0"
+    jss-nested "^6.0.1"
+    jss-props-sort "^6.0.0"
+    jss-template "^1.0.1"
+    jss-vendor-prefixer "^7.0.0"
+
+jss-props-sort@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/jss-props-sort/-/jss-props-sort-6.0.0.tgz#9105101a3b5071fab61e2d85ea74cc22e9b16323"
+
+jss-template@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/jss-template/-/jss-template-1.0.1.tgz#09aed9d86cc547b07f53ef355d7e1777f7da430a"
+  dependencies:
+    warning "^3.0.0"
+
+jss-vendor-prefixer@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/jss-vendor-prefixer/-/jss-vendor-prefixer-7.0.0.tgz#0166729650015ef19d9f02437c73667231605c71"
+  dependencies:
+    css-vendor "^0.3.8"
+
+jss@^9.7.0:
+  version "9.8.7"
+  resolved "https://registry.yarnpkg.com/jss/-/jss-9.8.7.tgz#ed9763fc0f2f0260fc8260dac657af61e622ce05"
+  dependencies:
+    is-in-browser "^1.1.3"
+    symbol-observable "^1.1.0"
     warning "^3.0.0"
 
 jss@^9.8.1:
@@ -6520,6 +6587,13 @@ prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.1:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.5.8:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  dependencies:
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 proxy-addr@~2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.3.tgz#355f262505a621646b3130a728eb647e22055341"
@@ -6763,6 +6837,16 @@ react-icons@^2.2.7:
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-2.2.7.tgz#d7860826b258557510dac10680abea5ca23cf650"
   dependencies:
     react-icon-base "2.1.0"
+
+react-jss@^8.6.1:
+  version "8.6.1"
+  resolved "https://registry.yarnpkg.com/react-jss/-/react-jss-8.6.1.tgz#a06e2e1d2c4d91b4d11befda865e6c07fbd75252"
+  dependencies:
+    hoist-non-react-statics "^2.5.0"
+    jss "^9.7.0"
+    jss-preset-default "^4.3.0"
+    prop-types "^15.6.0"
+    theming "^1.3.0"
 
 react-reconciler@^0.7.0:
   version "0.7.0"
@@ -8263,6 +8347,15 @@ text-encoding@^0.6.4:
 text-table@0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
+theming@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/theming/-/theming-1.3.0.tgz#286d5bae80be890d0adc645e5ca0498723725bdc"
+  dependencies:
+    brcast "^3.0.1"
+    is-function "^1.0.1"
+    is-plain-object "^2.0.1"
+    prop-types "^15.5.8"
 
 throat@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
## Reasons to Switch
* Clients need not worry about webpack/scss/global styles!!!!
* CSS in JS abstracts style to the component level.
* Doesn't require any web pack config for clients
  *  no build step, as a result—no dependency to build tools at all.
* Proper isolation preventing global side effects from greedy selectors (e.g. p)
  * No more global styles to worry about...everything is in the component
* Scalable 
* **Opens a path to react native with one codebase**
* Power of theming
* Runtime prefixes
* JSS styles size is up to 50% smaller
* Coupling of css with js allows using properties to compute styles 
  *  easily share constants and functions between JS and CSS\
* All CSS features included.
* Easy SSR

## Bundle Size
jss & react-jss adds ~9K gzipped which is nothing compared to the cost of removing all of the scss files and not having to worry about serving them. 

## Links to Share
* [Syntax Examples](http://cssinjs.org/json-api?v=v9.8.7#media-queries)
* [Creating Design System with css-in-js](https://medium.freecodecamp.org/css-in-javascript-the-future-of-component-based-styling-70b161a79a32)
* [Pros Cons](https://objectpartners.com/2017/11/03/css-in-js-benefits-drawbacks-and-tooling/)

<img width="815" alt="screen_shot_2018-07-28_at_4 31 58_pm" src="https://user-images.githubusercontent.com/8824977/43741621-db31df20-9983-11e8-9aff-d1862191b756.png">

## Components to Convert
It takes about 10-20 minutes to convert each at this point.

 - [X] Button
 - [ ] ButtonGroup
 - [ ] FloatingButton
 - [ ] FloatingButtonGroup
 - [X] Spinner
 - [ ] Input
 - [X] WDSIcon (New)
 - [ ] Fieldset
 - [X] BannerNotification
 - [ ] BannerNotifications
 - [ ] VideoPlayIcon
 - [ ] ContentWell
 - [ ] FandomContentWell
 - [ ] FandomBackgroundImage
 - [ ] Vignette
 - [ ] ExpandableText