### PR TITLE
Progressive Image Component

### DIFF
--- a/source/components/Image/README.md
+++ b/source/components/Image/README.md
@@ -1,0 +1,13 @@
+Image component with progressive image loading when the src is vignette. The image will first load with a 
+low resolution image (~10px) that will be automatically blurred in the most browsers.
+
+
+## Example usage
+
+Standard image:
+
+```
+<div>
+	<Image src="http://vignette.wikia-dev.us/22b12324-ab36-4266-87c9-452776157205" alt="fandom image"/>
+</div>
+```

--- a/source/components/Image/__snapshots__/index.spec.js.snap
+++ b/source/components/Image/__snapshots__/index.spec.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Image renders correctly 1`] = `
+Array [
+  <img
+    alt="Fandom"
+    className={null}
+    src=""
+    style={
+      Object {
+        "display": "block",
+      }
+    }
+  />,
+  <img
+    alt="Fandom"
+    className={null}
+    onLoad={[Function]}
+    src=""
+    srcSet={null}
+    style={
+      Object {
+        "display": "none",
+      }
+    }
+  />,
+  <noscript>
+    <img
+      alt="Fandom"
+      className={null}
+      src=""
+      srcSet={null}
+    />
+  </noscript>,
+]
+`;

--- a/source/components/Image/index.js
+++ b/source/components/Image/index.js
@@ -1,0 +1,108 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+// import Vignette from 'vignette';
+
+/**
+ * Create a super low resolution image that will automatically be blurred in most browsers
+ *
+ * @param vignetteUrl
+ * @returns {String}
+ */
+function getLowRes(vignetteUrl) {
+    return vignetteUrl;
+    // return Vignette.getThumbURL(vignetteUrl, {
+    //     mode: 'scale-to-width-down',
+    //     width: 5,
+    //     height: 5,
+    // });
+}
+
+class Image extends React.Component {
+    constructor(props) {
+        super(props);
+        const { src } = props;
+        this.onLoad = this.onLoad.bind(this);
+        this.state = {
+            src,
+            loading: true,
+            limbo: false,
+        };
+    }
+
+    // When the src changes first replace the src with a temp image so it doesn't stall displaying
+    // the old image
+    // https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#when-to-use-derived-state
+    static getDerivedStateFromProps(props, state) {
+        // when only the src changes we are in "limbo" mode
+        if (props.src !== state.src) {
+            return {
+                // try go get low resolution image of new image first
+                limbo: true,
+                loading: true,
+            };
+        }
+
+        return {
+            limbo: false,
+            loading: state.loading,
+        };
+    }
+
+    // after the component updates once we want to
+    componentDidUpdate() {
+        const { src: propsSrc } = this.props;
+        const { src: stateSrc } = this.state;
+
+        if (propsSrc !== stateSrc) {
+            // this is one of the rare cases to conditionally call setState after a component update
+            // this allows the images to be removed from the DOM properly
+            // eslint-disable-next-line react/no-did-update-set-state
+            this.setState(() => ({ src: propsSrc }));
+        }
+    }
+
+    onLoad() { this.setState(() => ({ loading: false })); }
+
+    render() {
+        const {
+            className, alt, src, srcSet, disableLazy, ...rest
+        } = this.props;
+
+        const { loading, limbo } = this.state;
+
+        if (disableLazy) {
+            return <img src={src} alt={alt} className={className} srcSet={srcSet} {...rest} />;
+        }
+
+        // Limbo state happens when only the src and/or srcset is changed
+        // there is no standard on how to handle the state of the image when the src is changed across browsers
+        // lets just remove the entire node from html when in limbo
+        return (
+            <React.Fragment>
+                {!limbo && <img src={getLowRes(src)} alt={alt} className={className} style={{ display: !loading ? 'none' : 'block' }} />}
+                {!limbo && <img onLoad={this.onLoad} src={src} alt={alt} className={className} style={{ display: loading ? 'none' : 'block' }} srcSet={srcSet} {...rest} />}
+
+                {/* // support SSR */}
+                <noscript>
+                    <img src={src} alt={alt} className={className} srcSet={srcSet} {...rest} />
+                </noscript>
+            </React.Fragment>
+        );
+    }
+}
+
+Image.propTypes = {
+    alt: PropTypes.string.isRequired,
+    className: PropTypes.string,
+    disableLazy: PropTypes.bool,
+    src: PropTypes.string.isRequired,
+    srcSet: PropTypes.string,
+};
+
+Image.defaultProps = {
+    className: null,
+    disableLazy: false,
+    srcSet: null,
+};
+
+export default Image;

--- a/source/components/Image/index.spec.js
+++ b/source/components/Image/index.spec.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import Image from './index';
+
+/* eslint-disable no-alert */
+
+test('Image renders correctly', () => {
+    const component = renderer.create(
+        <Image src="http://vignette.wikia-dev.us/22b12324-ab36-4266-87c9-452776157205" alt="Fandom" />,
+    );
+    expect(component.toJSON()).toMatchSnapshot();
+});
+
+//
+// test('FloatingButtonGroup renders correctly with a child (horizontal)', () => {
+//     const component = renderer.create(
+//         <FloatingButtonGroup>
+//             <FloatingButton>A</FloatingButton>
+//         </FloatingButtonGroup>,
+//     );
+//     expect(component.toJSON()).toMatchSnapshot();
+// });
+//
+// test('FloatingButtonGroup renders correctly with a child (vertical)', () => {
+//     const component = renderer.create(
+//         <FloatingButtonGroup vertical>
+//             <FloatingButton>A</FloatingButton>
+//         </FloatingButtonGroup>,
+//     );
+//     expect(component.toJSON()).toMatchSnapshot();
+// });

--- a/source/components/index.js
+++ b/source/components/index.js
@@ -24,6 +24,7 @@ export { default as FandomContentWell } from './FandomContentWell';
 // Other UI
 export { default as ExpandableText } from './ExpandableText';
 export { default as Vignette } from './Vignette';
+export { default as Image } from './Image';
 
 // custom types
 export { default as bannerNotificationsMessageType }
@@ -32,3 +33,4 @@ export { default as bannerNotificationsMessageType }
 // HEAVY icons
 export { default as IconSprite } from './IconSprite';
 export { default as Icon } from './Icon';
+

--- a/source/config/styleguide.config.json
+++ b/source/config/styleguide.config.json
@@ -60,7 +60,8 @@
     "components": [
       "FandomBackgroundImage",
       "Vignette",
-      "ExpandableText"
+      "ExpandableText",
+      "Image"
     ]
   }
 ]


### PR DESCRIPTION
I started moving https://github.com/Wikia/fandom-creator/pull/1345 into the RDS but I see there is a `Vignette` component. The component I'm building is meant to be a flexible generic image component that also takes of advantage of vignette when possible (i.e. `FandomImage` component ? )

I'm curious how we can best colsolidate these two. 

